### PR TITLE
switch to hydra 1.1

### DIFF
--- a/conf/averaged/ema.yaml
+++ b/conf/averaged/ema.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 _target_: timm.utils.ModelEmaV2
 decay: 0.999
 

--- a/conf/dataset/cifar10.yaml
+++ b/conf/dataset/cifar10.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 name: cifar10
 root: data/
 download: true # download if not already downloaded

--- a/conf/eval.yaml
+++ b/conf/eval.yaml
@@ -2,5 +2,5 @@ defaults:
   - dataset: cifar10
   - model: resnet20
   - misc: eval_misc
-  - hydra/job_logging: custom
-  - hydra/output: custom
+  - override hydra/job_logging: custom
+  - override hydra/output: custom

--- a/conf/hparams/default_cutout.yaml
+++ b/conf/hparams/default_cutout.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 epochs: 200
 batch_size: 128
 grad_clip_max_norm: null # change to float to activate

--- a/conf/hparams/default_he.yaml
+++ b/conf/hparams/default_he.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 # Roughly adapted, ResNet paper uses iterations instead
 epochs: 180
 batch_size: 128

--- a/conf/hydra/job_logging/custom.yaml
+++ b/conf/hydra/job_logging/custom.yaml
@@ -1,5 +1,3 @@
-# @package _group_
-
 # python logging configuration for tasks
 version: 1
 formatters:

--- a/conf/misc/tune_misc.yaml
+++ b/conf/misc/tune_misc.yaml
@@ -5,6 +5,7 @@ auto_cpu_if_no_gpu: true
 device: cuda:0
 save: true
 global_seed: null
+maximize_averaged: true
 
 dataset:
   train:

--- a/conf/model/resnet18.yaml
+++ b/conf/model/resnet18.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 # From He et al., originally designed for ImageNet and adapted for CIFAR
 _target_: src.network.resnet_imagenet.resnet18
 num_classes: 10

--- a/conf/model/resnet20.yaml
+++ b/conf/model/resnet20.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 # From He et al., specifically designed for CIFAR
 _target_: src.network.resnet_cifar.resnet20
 num_classes: 10

--- a/conf/model/resnet50.yaml
+++ b/conf/model/resnet50.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 # From He et al., originally designed for ImageNet and adapted for CIFAR
 _target_: src.network.resnet_imagenet.resnet50
 num_classes: 10

--- a/conf/model/resnet56.yaml
+++ b/conf/model/resnet56.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 # From He et al. paper, specifically designed for resnet
 _target_: src.network.resnet_cifar.resnet56
 num_classes: 10

--- a/conf/optimizer/adam.yaml
+++ b/conf/optimizer/adam.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 _target_: torch.optim.Adam
 lr: 0.001
 weight_decay: 1e-4

--- a/conf/optimizer/momentum.yaml
+++ b/conf/optimizer/momentum.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 # Setting from ResNet paper
 _target_: torch.optim.SGD
 lr: 0.1

--- a/conf/optimizer/nesterov_cutout.yaml
+++ b/conf/optimizer/nesterov_cutout.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 # Setting from cutout paper
 _target_: torch.optim.SGD
 lr: 0.1

--- a/conf/scheduler/constant.yaml
+++ b/conf/scheduler/constant.yaml
@@ -1,3 +1,2 @@
-# @package _group_
 _target_: src.scheduler.WarmupConstantSchedule
 warmup_steps: 0

--- a/conf/scheduler/cosine.yaml
+++ b/conf/scheduler/cosine.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 _target_: src.scheduler.WarmupCosineSchedule
 warmup_steps: 0
 t_total: auto

--- a/conf/scheduler/linear.yaml
+++ b/conf/scheduler/linear.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 _target_: src.scheduler.WarmupLinearSchedule
 warmup_steps: 0
 t_total: auto

--- a/conf/scheduler/multistep_cutout.yaml
+++ b/conf/scheduler/multistep_cutout.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 _target_: torch.optim.lr_scheduler.MultiStepLR
 milestones: [60, 120, 160]
 gamma: 0.2

--- a/conf/scheduler/multistep_he.yaml
+++ b/conf/scheduler/multistep_he.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 # Roughly adapted from ResNet paper, which uses iterations instead
 _target_: torch.optim.lr_scheduler.MultiStepLR
 milestones: [90, 135]

--- a/conf/scheduler/multistep_mini.yaml
+++ b/conf/scheduler/multistep_mini.yaml
@@ -1,0 +1,4 @@
+# Roughly adapted from ResNet paper, which uses iterations instead
+_target_: torch.optim.lr_scheduler.MultiStepLR
+milestones: [90, 135]
+gamma: 0.1

--- a/conf/scheduler/step_effnet.yaml
+++ b/conf/scheduler/step_effnet.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 # Decreases it using the 0.97 constant used in many recent papers (e.g. EffNet)
 _target_: torch.optim.lr_scheduler.StepLR
 step_size: 2

--- a/conf/train.yaml
+++ b/conf/train.yaml
@@ -6,5 +6,5 @@ defaults:
   - scheduler: multistep_he
   - averaged: ema
   - misc: train_misc
-  - hydra/job_logging: custom
-  - hydra/output: custom
+  - override hydra/job_logging: custom
+  - override hydra/output: custom

--- a/conf/tune.yaml
+++ b/conf/tune.yaml
@@ -6,17 +6,17 @@ defaults:
   - scheduler: multistep
   - averaged: ema
   - misc: tune_misc
-  - hydra/sweeper: optuna
-  - hydra/job_logging: custom
-  - hydra/output: custom
+  - override hydra/sweeper: optuna
+  - override hydra/sweeper/sampler: tpe
+  - override hydra/job_logging: custom
+  - override hydra/output: custom
 
 hydra:
   sweeper:
-    optuna_config:
-      direction: maximize
-      study_name: ${hydra.job.name}/${dataset.name}/${now:%Y-%m-%d_%H-%M-%S}
-      storage: sqlite:///results/tuning.db
-      n_trials: 20
-      n_jobs: 1
-      sampler: tpe
+    sampler:
       seed: null
+    direction: maximize
+    study_name: ${hydra.job.name}/${dataset.name}/${now:%Y-%m-%d_%H-%M-%S}
+    storage: sqlite:///results/tuning.db
+    n_trials: 20
+    n_jobs: 1

--- a/conf/tune.yaml
+++ b/conf/tune.yaml
@@ -1,9 +1,9 @@
 defaults:
   - dataset: cifar10
-  - model: resnet18
-  - hparams: default
-  - optimizer: sgd
-  - scheduler: multistep
+  - model: resnet20
+  - hparams: default_he
+  - optimizer: momentum
+  - scheduler: multistep_he
   - averaged: ema
   - misc: tune_misc
   - override hydra/sweeper: optuna
@@ -18,5 +18,5 @@ hydra:
     direction: maximize
     study_name: ${hydra.job.name}/${dataset.name}/${now:%Y-%m-%d_%H-%M-%S}
     storage: sqlite:///results/tuning.db
-    n_trials: 20
+    n_trials: 30
     n_jobs: 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ scipy
 torch>=1.7
 torchvision
 tensorboard
-hydra-core
+hydra-core>=1.1.0
 optuna
 hydra-optuna-sweeper
 tqdm

--- a/src/runner.py
+++ b/src/runner.py
@@ -196,7 +196,7 @@ def evaluate(
         evaluator = Evaluator(
             model=model,
             device=device,
-            loader=test_loader,
+            loader=val_loader,
             checkpoint_path=checkpoint_path,
         )
         val_acc = evaluator.evaluate()

--- a/tune.py
+++ b/tune.py
@@ -18,3 +18,4 @@ def tune(cfg: DictConfig):
 
 if __name__ == "__main__":
     tune()
+

--- a/tune.py
+++ b/tune.py
@@ -10,7 +10,10 @@ def tune(cfg: DictConfig):
     utils.display_config(cfg)
     accuracies = runner.train(cfg)
 
-    return accuracies["final_averaged"][1]
+    if cfg.maximize_averaged:
+        return accuracies["final_averaged"][1]
+    else:
+        return accuracies["final"][1]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Updates configuration to be compatible with Hydra 1.1 (and higher). Deprecate support for Hydra 1.0.

More info:
Hydra 1.1 release: https://hydra.cc/blog/2021/06/13/Hydra_1.1
Upgrading Hydra version: https://hydra.cc/docs/upgrades/intro